### PR TITLE
docs: Add korean document into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ This repository is for studying of OpenGL and other graphic libraries such as Di
   - All code samples and images are licensed under the terms of the CC BY-NC 4.0 license as published by Creative Commons. [A human-readable format of the license](https://creativecommons.org/licenses/by-nc/4.0/). and the full license are [here](https://creativecommons.org/licenses/by/4.0/legalcode). and I give great thanks to [JoeyDeVriez](https://twitter.com/JoeyDeVriez) for making the greatest [OpenGL tutorial](https://learnopengl.com/).
   - Code samples use [glfw](https://github.com/glfw/glfw), [glew](https://github.com/nigels-com/glew), [stb_image header library](https://github.com/nothings/stb), and [glm](https://github.com/g-truc/glm).
 
+---
+`Korean`
+
+이 레포지터리는 OpenGL, DirectX 을 비롯한 그래픽 라이브러리 및 관련된 자료를 공부한 스터디 자료, 메모, 결과물을 정리한 곳입니다. 현재까지 모든 문서들은 한글로 제공되고 있으며 자유롭게 읽으실 수 있거나 issue 등으로 질문을 하실 수 있습니다.
+
+- 주의사항
+  - ***원 저작자의 동의 없이 번역된 글 등은 관계자의 요청이 있을 시 사전 통지없이 바로 지워질 수 있습니다.***
+  - 갱신되는 문서들은 $LaTex$ 구문과 같은 확장 문법을 사용하고 있습니다. github 자체에서 읽으셔도 상관은 없으나 문제 없이 읽기 위해서는 [`Typora`](https://typora.io/) 를 사용해서 마크다운 파일을 읽는 것을 권장하고 있습니다.
+  - 모든 문서들은 *Typora* 로 작성하고 있습니다.
+  - 재작성된 모든 코드 샘플 및 이미지들은 CC BY-NC 4.0 라이센스에 준거하고 있습니다. 라이센스 문서에 관해서는 다음을 참고해주세요.
+    - [A human-readable format of the license](https://creativecommons.org/licenses/by-nc/4.0/)
+    - [The full license](https://creativecommons.org/licenses/by/4.0/legalcode)
+  - OpenGL 을 사용하는 코드는 [glfw](https://github.com/glfw/glfw), [glew](https://github.com/nigels-com/glew), [stb_image header library](https://github.com/nothings/stb), and [glm](https://github.com/g-truc/glm) 의 설치가 필요합니다.
 
 ---
 


### PR DESCRIPTION
following issue #2, Add korean document into README.

[x] Write preface in Korean.
[x] Write precaution also.
[x] The reminder (on-going, and so on) does not have to be written newly.
[ ] Placement has to be before log section.

I think that the placement has to be before on-going section, so take into about this.
And need to revise english writing more appropriately.